### PR TITLE
Fix compiler error

### DIFF
--- a/ledger.cpp
+++ b/ledger.cpp
@@ -48,10 +48,10 @@ void Ledger::readFile(QTextStream *inputStream)
     }
     undoStack->setClean();
     // setup signals
-    connect(this,&QAbstractItemModel::dataChanged, this,&computeTotal);
-    connect(this,&QAbstractItemModel::rowsRemoved, this,&computeTotal);
-    connect(this,&QAbstractItemModel::rowsInserted,this,&computeTotal);
-    connect(undoStack,&QUndoStack::cleanChanged, this,&sendChangeSignal);
+    connect(this,&QAbstractItemModel::dataChanged, this,&Ledger::computeTotal);
+    connect(this,&QAbstractItemModel::rowsRemoved, this,&Ledger::computeTotal);
+    connect(this,&QAbstractItemModel::rowsInserted,this,&Ledger::computeTotal);
+    connect(undoStack,&QUndoStack::cleanChanged, this,&Ledger::sendChangeSignal);
 }
 
 bool Ledger::readCsv(QTextStream *stream)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -201,7 +201,7 @@ void MainWindow::setupLedger(QTextStream * inputStream)
     openingMsg->hide();
     ui->ledgerView->setLedger(ledger);
 
-    connect(ledger,&Ledger::ledgerChanged,this,&setWindowModified);
+    connect(ledger,&Ledger::ledgerChanged,this,&MainWindow::setWindowModified);
     connect(ledger,&Ledger::ledgerChanged,ui->actionSave,&QAction::setEnabled);
 }
 


### PR DESCRIPTION
ISO C++ forbids taking the address of an unqualified or parenthesized non-static member function to form a pointer to member function
